### PR TITLE
update selector

### DIFF
--- a/src/main/java/io/github/mwrod453/mvn/MvnArtifactVersion.java
+++ b/src/main/java/io/github/mwrod453/mvn/MvnArtifactVersion.java
@@ -7,7 +7,7 @@ import pl.droidsonroids.jspoon.annotation.Selector;
  */
 public class MvnArtifactVersion {
 
-    @Selector("#maincontent > table > tbody .lic")
+    @Selector("main > .content > table > tbody td > .lic")
     private String license;
 
     /**


### PR DESCRIPTION
Bei uns im `dependecychecker-maven-plugin` kam als Output für Mavens Lizenzen immer `null` raus. Wir benutzen dieses Paket für das abfragen der Lizenzen auf mvnrepository.

Mvnrepository hat wohl die DOM Struktur verändert, weshalb der Selektor nicht mehr funktioniert hat. Tests schlagen auf dem Master fehl, mit diesem PR laufen die Tests wieder.